### PR TITLE
Add RDF file specifying Onset type for chord onsets output

### DIFF
--- a/score-aligner.n3
+++ b/score-aligner.n3
@@ -1,0 +1,132 @@
+@prefix rdfs:     <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd:      <http://www.w3.org/2001/XMLSchema#> .
+@prefix vamp:     <http://purl.org/ontology/vamp/> .
+@prefix plugbase: <http://vamp-plugins.org/rdf/plugins/score-aligner#> .
+@prefix owl:      <http://www.w3.org/2002/07/owl#> .
+@prefix dc:       <http://purl.org/dc/elements/1.1/> .
+@prefix af:       <http://purl.org/ontology/af/> .
+@prefix foaf:     <http://xmlns.com/foaf/0.1/> .
+@prefix doap:     <http://usefulinc.com/ns/doap#> .
+@prefix cc:       <http://web.resource.org/cc/> .
+@prefix :         <#> .
+
+
+## Properties of this document
+
+<> a vamp:PluginDescription ;
+    foaf:maker         <http://vamp-plugins.org/rdf/template-generator> ;
+    foaf:primaryTopic  <http://vamp-plugins.org/rdf/plugins/score-aligner> .
+
+
+## Maker of the whole plugin library
+
+:library_maker
+    foaf:name  "Yucong Jiang" ;
+#   foaf:page  <> ;  # Place maker's homepage URL in here and uncomment
+#   foaf:logo  <> ;  # URL of an image here, if you happen to have a logo
+    .
+
+
+## Properties of the plugin library, and references to the plugins it contains
+
+plugbase:library a vamp:PluginLibrary ;
+    vamp:identifier        "score-aligner" ;
+    foaf:maker             :library_maker ; 
+    vamp:available_plugin  plugbase:pianoaligner ; 
+#   dc:title               "" ;  # Place library name here and uncomment
+#   dc:description         "" ;  # Place library description here and uncomment
+#   foaf:page              <> ;  # Place more-info HTML page URL here and uncomment
+#   doap:download-page     <> ;  # Place download HTML page URL here and uncomment
+    .
+
+
+## Properties of the Piano Aligner plugin
+
+plugbase:pianoaligner a vamp:Plugin ;
+    dc:title              "Piano Aligner" ;
+    vamp:name             "Piano Aligner" ;
+    dc:description        """A dummy plugin created by YJ.""" ;
+    foaf:maker            :library_maker ;
+    dc:rights             """Copyright (2021). All Rights Reserved""" ;
+#   cc:license            <Place plugin license URI here and uncomment> ; 
+    vamp:identifier       "pianoaligner" ;
+    vamp:vamp_API_version vamp:api_version_2 ;
+    owl:versionInfo       "1" ;
+    vamp:input_domain     vamp:FrequencyDomain ;
+
+    vamp:parameter   plugbase:pianoaligner_param_parameter ;
+
+    vamp:output      plugbase:pianoaligner_output_testsimplehmm ;
+    vamp:output      plugbase:pianoaligner_output_testingtemplates ;
+    vamp:output      plugbase:pianoaligner_output_testingpowerspectrum ;
+    vamp:output      plugbase:pianoaligner_output_chordonsets ;
+    vamp:output      plugbase:pianoaligner_output_eventtempo ;
+    .
+plugbase:pianoaligner_param_parameter a  vamp:Parameter ;
+    vamp:identifier     "parameter" ;
+    dc:title            "Some Parameter" ;
+    dc:format           "" ;
+    vamp:min_value       0 ;
+    vamp:max_value       10 ;
+    vamp:unit           ""  ;
+    vamp:default_value   5 ;
+    vamp:value_names     ();
+    .
+plugbase:pianoaligner_output_testsimplehmm a  vamp:DenseOutput ;
+    vamp:identifier       "testsimplehmm" ;
+    dc:title              "Testing Simple HMM" ;
+    dc:description        """Testing for pianoaligner"""  ;
+    vamp:fixed_bin_count  "true" ;
+    vamp:unit             "" ;
+    vamp:bin_count        1 ;
+#   vamp:computes_event_type   <Place event type URI here and uncomment> ;
+#   vamp:computes_feature      <Place feature attribute URI here and uncomment> ;
+#   vamp:computes_signal_type  <Place signal type URI here and uncomment> ;
+    .
+plugbase:pianoaligner_output_testingtemplates a  vamp:DenseOutput ;
+    vamp:identifier       "testingtemplates" ;
+    dc:title              "Testing Templates" ;
+    dc:description        """Testing the templates"""  ;
+    vamp:fixed_bin_count  "true" ;
+    vamp:unit             "" ;
+    vamp:bin_count        512 ;
+#   vamp:computes_event_type   <Place event type URI here and uncomment> ;
+#   vamp:computes_feature      <Place feature attribute URI here and uncomment> ;
+#   vamp:computes_signal_type  <Place signal type URI here and uncomment> ;
+    .
+plugbase:pianoaligner_output_testingpowerspectrum a  vamp:DenseOutput ;
+    vamp:identifier       "testingpowerspectrum" ;
+    dc:title              "Testing Power Spectrum" ;
+    dc:description        """Normalized values"""  ;
+    vamp:fixed_bin_count  "true" ;
+    vamp:unit             "" ;
+    vamp:bin_count        512 ;
+#   vamp:computes_event_type   <Place event type URI here and uncomment> ;
+#   vamp:computes_feature      <Place feature attribute URI here and uncomment> ;
+#   vamp:computes_signal_type  <Place signal type URI here and uncomment> ;
+    .
+plugbase:pianoaligner_output_chordonsets a  vamp:SparseOutput ;
+    vamp:identifier       "chordonsets" ;
+    dc:title              "Chord Onsets" ;
+    dc:description        """Chord onsets by the dummy plugin"""  ;
+    vamp:fixed_bin_count  "true" ;
+    vamp:unit             "" ;
+    vamp:bin_count        1 ;
+    vamp:sample_type      vamp:VariableSampleRate ;
+    vamp:sample_rate      57.4219 ;
+    vamp:computes_event_type  af:Onset ;
+    .
+plugbase:pianoaligner_output_eventtempo a  vamp:SparseOutput ;
+    vamp:identifier       "eventtempo" ;
+    dc:title              "Event Tempo" ;
+    dc:description        """Tempo of an event"""  ;
+    vamp:fixed_bin_count  "true" ;
+    vamp:unit             "" ;
+    vamp:bin_count        1 ;
+    vamp:sample_type      vamp:VariableSampleRate ;
+    vamp:sample_rate      57.4219 ;
+#   vamp:computes_event_type   <Place event type URI here and uncomment> ;
+#   vamp:computes_feature      <Place feature attribute URI here and uncomment> ;
+#   vamp:computes_signal_type  <Place signal type URI here and uncomment> ;
+    .
+


### PR DESCRIPTION
The RDF file was generated using the `vamp-rdf-template-generator` tool in the Vamp plugin SDK; I then added an event type for the chord onsets output. That's the only change from the default.

With this in the `VAMP_PATH` alongside the plugin, SV has the information it needs to determine that the output is intended to represent onsets - whether it does anything with that information obviously depends on the SV code!