### PR TITLE
Support multiple score paths and an environment variable to override

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .DS_Store
 *.o
 *.dylib
-
+*~

--- a/AudioToScoreAligner.cpp
+++ b/AudioToScoreAligner.cpp
@@ -5,6 +5,7 @@
 
 #include "AudioToScoreAligner.h"
 #include "Templates.h"
+#include "Paths.h"
 #include "SimpleHMM.h"
 
 #include <cmath>
@@ -24,63 +25,23 @@ AudioToScoreAligner::~AudioToScoreAligner()
 bool AudioToScoreAligner::loadAScore(string scoreName, int blockSize)
 {
     std::cerr << "In loadAScore: scoreName is -> " << scoreName << '\n';
-    std::filesystem::path scoreDir = string(getenv("HOME")) + "/Documents/SV-PianoPrecision/Scores";
-    if (!exists(scoreDir)) {
-        std::cerr << "Score directory ($Home/Documents/SV-PianoPrecision/Scores) does not exist!" << '\n';
+
+    auto scores = Paths::getScores();
+
+    if (scores.find(scoreName) == scores.end()) {
+        std::cerr << "Score not found: " << scoreName << '\n';
         return false;
     }
-    std::filesystem::path targetPath;
-    for (const auto& entry : std::filesystem::directory_iterator(scoreDir)) {
-        string folderName = string(entry.path().filename());
-        if (folderName == scoreName) {
-            targetPath = entry.path();
-            break;
-        }
-    }
-    if (!exists(targetPath)) {
-        std::cerr << "Score folder not found: " << targetPath << '\n';
-        return false;
-    }
+
+    std::filesystem::path targetPath = scores[scoreName];
+
+    // Paths::getScores() has already verified that these exist
     std::filesystem::path scorePath = string(targetPath) + "/" + scoreName + ".solo";
-    if (!exists(scorePath)) {
-        std::cerr << "Score file (.solo) not found:" << scorePath << '\n';
-        return false;
-    }
     std::filesystem::path scoreTempoPath = string(targetPath) + "/" + scoreName + ".tempo";
-    if (!exists(scoreTempoPath)) {
-        std::cerr << "Score tempo file (.tempo) not found:" << scoreTempoPath << '\n';
-        return false;
-    }
 
-    string testScorePath = string(scorePath);
-    std::cerr << "In loadAScore: testScorePath is -> " << testScorePath << '\n';
-    
-    string testScoreTempoPath = string(scoreTempoPath);
-    std::cerr << "In loadAScore: testScoreTempoPath is -> " << testScoreTempoPath << '\n';
-    
-
-/*
-    string testScorePath = "/Users/yjiang3/Desktop/Pilot/BothHandsC/BothHandsC.solo";
-    if (scoreName == "BothHandsC") {
-        testScorePath = "/Users/yjiang3/Desktop/Pilot/BothHandsC/BothHandsC.solo";
-    } else if (scoreName == "ContraryArpeggioC") {
-        testScorePath = "/Users/yjiang3/Desktop/Pilot/ContraryArpeggioC/ContraryArpeggioC.solo";
-    } else if (scoreName == "ContraryC") {
-        testScorePath = "/Users/yjiang3/Desktop/Pilot/ContraryC/ContraryC.solo";
-    } else if (scoreName == "LeftHandOnlyC") {
-        testScorePath = "/Users/yjiang3/Desktop/Pilot/LeftHandOnlyC/LeftHandOnlyC.solo";
-    } else if (scoreName == "OneHandOnlyArpeggioC") {
-        testScorePath = "/Users/yjiang3/Desktop/Pilot/OneHandOnlyArpeggioC/OneHandOnlyArpeggioC.solo";
-    } else if (scoreName == "RightHandOnlyC") {
-        testScorePath = "/Users/yjiang3/Desktop/Pilot/RightHandOnlyC/RightHandOnlyC.solo";
-    } else {
-        std::cerr << "scoreName not found in AudioToScoreAligner::loadAScore" << '\n';
-    }
-    */
-
-    bool success = m_score.initialize(testScorePath);
+    bool success = m_score.initialize(scorePath);
     if (success) {
-        success = m_score.readTempo(testScoreTempoPath);
+        success = m_score.readTempo(scoreTempoPath);
     }
 
     NoteTemplates t =

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -29,11 +29,11 @@ PLUGIN_LIBRARY_NAME := score-aligner
 
 # Edit this to list the .cpp or .c files in your plugin project
 #
-PLUGIN_SOURCES := PianoAligner.cpp Score.cpp AudioToScoreAligner.cpp plugins.cpp Templates.cpp SimpleHMM.cpp
+PLUGIN_SOURCES := PianoAligner.cpp Score.cpp AudioToScoreAligner.cpp plugins.cpp Templates.cpp SimpleHMM.cpp Paths.cpp
 
 # Edit this to list the .h files in your plugin project
 #
-PLUGIN_HEADERS := PianoAligner.h Score.h AudioToScoreAligner.cpp Templates.h SimpleHMM.h
+PLUGIN_HEADERS := PianoAligner.h Score.h AudioToScoreAligner.cpp Templates.h SimpleHMM.h Paths.h
 
 
 ##  Normally you should not edit anything below this line

--- a/Paths.cpp
+++ b/Paths.cpp
@@ -1,0 +1,104 @@
+
+#include "Paths.h"
+
+#include <iostream>
+
+using std::vector;
+using std::filesystem::path;
+using std::filesystem::directory_iterator;
+using std::string;
+using std::map;
+using std::cerr;
+using std::endl;
+
+static vector<path> splitPath(string str)
+{
+#ifdef _WIN32
+#define PATH_SEPARATOR ';'
+#else
+#define PATH_SEPARATOR ':'
+#endif
+
+    vector<path> pp;
+    path p;
+    string::size_type index = 0, newindex = 0;
+    while ((newindex = str.find(PATH_SEPARATOR, index)) < str.size()) {
+	p = path(str.substr(index, newindex - index));
+        pp.push_back(p);
+	index = newindex + 1;
+    }
+    p = path(str.substr(index));
+    pp.push_back(p);
+    return pp;
+}
+
+vector<path>
+Paths::getScoreDirectories()
+{
+    vector<path> pp;
+    auto envPath = getenv("PIANO_ALIGNER_SCORE_PATH");
+    if (envPath) {
+        pp = splitPath(string(envPath));
+    } else {
+        auto home = getenv("HOME");
+        if (!home) return {};
+        pp.push_back(path(string(home) + "/Documents/PianoPrecision/Scores"));
+    }
+    return pp;
+}
+
+map<string, path>
+Paths::getScores()
+{
+    auto dirs = getScoreDirectories();
+    int dirsThatExist = 0;
+    map<string, path> scores;
+
+    for (auto dir : dirs) {
+
+        if (!exists(dir)) continue;
+        ++dirsThatExist;
+
+        for (auto entry : directory_iterator(dir)) {
+
+            path candidate = entry.path();
+            string name(candidate.filename());
+            if (name.size() == 0 || name[0] == '.' ||
+                scores.find(name) != scores.end()) {
+                continue;
+            }
+
+            path scoreFile(string(candidate) + "/" + name + ".solo");
+            if (!exists(scoreFile)) {
+                cerr << "WARNING: Candidate score folder "
+                     << candidate << " lacks " << name << ".solo file"
+                     << endl;
+                continue;
+            }
+
+            path tempoFile(string(candidate) + "/" + name + ".tempo");
+            if (!exists(tempoFile)) {
+                cerr << "WARNING: Candidate score folder "
+                     << candidate << " lacks " << name << ".tempo file"
+                     << endl;
+                continue;
+            }
+
+            cerr << "Found valid-looking score folder: " << candidate << endl;
+            scores[name] = candidate;
+        }
+    }
+
+    if (dirsThatExist == 0) {
+        cerr << "WARNING: None of the specified score folders exists!" << endl;
+        cerr << "Folders are:" << endl;
+        for (auto dir : dirs) {
+            cerr << dir << endl;
+        }
+    }
+    
+    return scores;
+}
+
+
+

--- a/Paths.h
+++ b/Paths.h
@@ -1,0 +1,43 @@
+
+#ifndef PIANO_ALIGNER_PATHS_H
+#define PIANO_ALIGNER_PATHS_H
+
+#include <filesystem>
+#include <vector>
+#include <map>
+#include <string>
+
+class Paths
+{
+public:
+    /**
+     * Return a list of directories to be searched for scores.
+     *
+     * If the environment variable PIANO_ALIGNER_SCORE_PATH is set,
+     * its contents will be treated as a semicolon-separated (on
+     * Windows) or colon-separated (elsewhere) list of directories and
+     * will be returned here. Otherwise the single entry
+     * $HOME/Documents/PianoPrecision/Scores will be used.
+     *
+     * Return an empty vector if the environment variable is set but
+     * cannot be used for some reason, or if $HOME is not set.  Note
+     * that this function does not check that the directories exist.
+     */
+    static std::vector<std::filesystem::path> getScoreDirectories();
+
+    /**
+     * Return a list of scores found in the score directories. Each
+     * score is also a directory, containing (at least) .solo and
+     * .tempo files. The returned value maps from score name to score
+     * directory.
+     *
+     * This function only returns scores whose directories exist and
+     * contain appropriately-named .solo and .tempo files.
+     *
+     * If more than one of the score directories contains a score with
+     * a given name, the first one found takes priority.
+     */
+    static std::map<std::string, std::filesystem::path> getScores();
+};
+
+#endif

--- a/PianoAligner.cpp
+++ b/PianoAligner.cpp
@@ -6,6 +6,7 @@
 #include "AudioToScoreAligner.h"
 
 #include "Templates.h"
+#include "Paths.h"
 #include "Score.h" // delete later
 #include <cmath> // delete later
 #include <filesystem>
@@ -166,17 +167,13 @@ PianoAligner::getPrograms() const
 {
     ProgramList list;
 
-    std::filesystem::path scoreDir = string(getenv("HOME")) + "/Documents/SV-PianoPrecision/Scores";
-    if (!exists(scoreDir)) {
-        std::cerr << "Score directory ($Home/Documents/SV-PianoPrecision/Scores) does not exist!" << '\n';
-        return list;
-    }
-    std::filesystem::path targetPath;
-    for (const auto& entry : std::filesystem::directory_iterator(scoreDir)) {
-        string folderName = string(entry.path().filename());
-        if (folderName[0] == '.') continue;
-        list.push_back(folderName);
-        std::cerr << folderName << '\n';
+    auto scores = Paths::getScores();
+
+    std::cerr << "PianoAligner::getPrograms: have " << scores.size() << " scores" << std::endl;
+
+    for (auto score : scores) {
+        std::cerr << "PianoAligner::getPrograms: score " << score.first << std::endl;
+        list.push_back(score.first);
     }
 
     // If you have no programs, return an empty list (or simply don't


### PR DESCRIPTION
So that a piano-precision instance can load scores both within and without its app bundle or installation directory. The matching logic in piano-precision itself is not quite done yet but this passes initial tests and gives an idea of what I have in mind.