### PR TITLE
Add a toLabel method to MeasureInfo, + some housekeeping

### DIFF
--- a/AudioToScoreAligner.cpp
+++ b/AudioToScoreAligner.cpp
@@ -12,6 +12,7 @@
 #include <filesystem>
 #include <vector>
 
+using namespace std;
 
 AudioToScoreAligner::AudioToScoreAligner(float inputSampleRate, int hopSize,
 int startEvent, int endEvent, int startFrame, int endFrame) :
@@ -26,21 +27,21 @@ AudioToScoreAligner::~AudioToScoreAligner()
 
 bool AudioToScoreAligner::loadAScore(string scoreName, int blockSize)
 {
-    std::cerr << "In loadAScore: scoreName is -> " << scoreName << '\n';
+    cerr << "In loadAScore: scoreName is -> " << scoreName << '\n';
 
     auto scores = Paths::getScores();
 
     if (scores.find(scoreName) == scores.end()) {
-        std::cerr << "Score not found: " << scoreName << '\n';
+        cerr << "Score not found: " << scoreName << '\n';
         return false;
     }
 
-    std::filesystem::path targetPath = scores[scoreName];
+    filesystem::path targetPath = scores[scoreName];
 
     // Paths::getScores() has already verified that these exist
-    std::string scorePath = targetPath.string() + "/" + scoreName + ".solo";
-    std::string scoreTempoPath = targetPath.string() + "/" + scoreName + ".tempo";
-    std::string scoreMeterPath = targetPath.string() + "/" + scoreName + ".meter";
+    string scorePath = targetPath.string() + "/" + scoreName + ".solo";
+    string scoreTempoPath = targetPath.string() + "/" + scoreName + ".tempo";
+    string scoreMeterPath = targetPath.string() + "/" + scoreName + ".meter";
 
     bool success = m_score.initialize(scorePath);
     if (success)    success = m_score.readTempo(scoreTempoPath);
@@ -64,10 +65,10 @@ void AudioToScoreAligner::initializeLikelihoods()
     int frames = m_dataFeatures.size();
     int events = m_score.getMusicalEvents().size();
     if (frames == 0) {
-        std::cerr << "AudioToScoreAligner::initializeLikelihoods:\
+        cerr << "AudioToScoreAligner::initializeLikelihoods:\
         features are not supplied." << '\n';
     }
-    std::cerr << "AudioToScoreAligner::initializeLikelihoods:\
+    cerr << "AudioToScoreAligner::initializeLikelihoods:\
     features are indeed supplied. Number of frames = " << frames << '\n';
     for (int frame = 0; frame < frames; frame++) {
         vector<Likelihood> l;
@@ -90,7 +91,7 @@ void AudioToScoreAligner::initializeLikelihoods()
 double AudioToScoreAligner::getLikelihood(int frame, int event)
 {
     if (m_dataFeatures.size() == 0) {
-        std::cerr << "AudioToScoreAligner::getLikelihood:\
+        cerr << "AudioToScoreAligner::getLikelihood:\
         features are not supplied." << '\n';
     }
     static Template silenceTemplate;
@@ -114,30 +115,30 @@ double AudioToScoreAligner::getLikelihood(int frame, int event)
     // TODO: check the range for frame and event
     // If event < 0, use a different template:
     if (event < 0) {
-        if(!m_silenceLikelihoods[frame][std::abs(event)-1].calculated) {
+        if(!m_silenceLikelihoods[frame][abs(event)-1].calculated) {
             double score = 0;
             for (int bin = 0; bin < int(m_dataFeatures[frame].size()); bin++) {
                 score += m_dataFeatures[frame][bin]*log(silenceTemplate[bin]);
                 /*
                 if (frame == 2 && event == -1) {
                     if (isnan(score)) {
-                        std::cout << "bin="<<bin<<", score="<<score << '\n';
-                        std::cout << "bin value: "<<m_dataFeatures[frame][bin] << '\n';
-                        std::cout << "template value: "<<silenceTemplate[bin] << '\n';
+                        cout << "bin="<<bin<<", score="<<score << '\n';
+                        cout << "bin value: "<<m_dataFeatures[frame][bin] << '\n';
+                        cout << "template value: "<<silenceTemplate[bin] << '\n';
                     }
                 }
                 */
             }
-            m_silenceLikelihoods[frame][std::abs(event)-1].likelihood = exp(score);
-            m_silenceLikelihoods[frame][std::abs(event)-1].calculated = true;
+            m_silenceLikelihoods[frame][abs(event)-1].likelihood = exp(score);
+            m_silenceLikelihoods[frame][abs(event)-1].calculated = true;
             /*
-            if (isnan(m_silenceLikelihoods[frame][std::abs(event)-1].likelihood)) {
-                std::cerr << "Frame="<<frame << ", event="<<event<<'\n';
-                std::cerr << "like="<<m_silenceLikelihoods[frame][std::abs(event)-1].likelihood << '\n';
+            if (isnan(m_silenceLikelihoods[frame][abs(event)-1].likelihood)) {
+                cerr << "Frame="<<frame << ", event="<<event<<'\n';
+                cerr << "like="<<m_silenceLikelihoods[frame][abs(event)-1].likelihood << '\n';
             }
             */
         }
-        return m_silenceLikelihoods[frame][std::abs(event)-1].likelihood;
+        return m_silenceLikelihoods[frame][abs(event)-1].likelihood;
     }
 
     if (!m_likelihoods[frame][event].calculated) {

--- a/AudioToScoreAligner.h
+++ b/AudioToScoreAligner.h
@@ -11,9 +11,6 @@
 
 #include <vector>
 
-using std::vector;
-
-
 
 class AudioToScoreAligner
 {
@@ -33,14 +30,14 @@ public:
         bool calculated;
         Likelihood(double l, bool c) : likelihood{l}, calculated{c} { }
     };
-    typedef vector<vector<Likelihood>> DataLikelihoods;
-    typedef vector<float> DataSpectrum;
-    typedef vector<DataSpectrum> DataFeatures;
+    typedef std::vector<std::vector<Likelihood>> DataLikelihoods;
+    typedef std::vector<float> DataSpectrum;
+    typedef std::vector<DataSpectrum> DataFeatures;
 
     //typedef std::vector<Vamp::RealTime> AlignmentResults;
-    typedef vector<int> AlignmentResults;
+    typedef std::vector<int> AlignmentResults;
 
-    bool loadAScore(string scoreName, int blockSize);
+    bool loadAScore(std::string scoreName, int blockSize);
     void supplyFeature(DataSpectrum s);
     AlignmentResults align();
     float getSampleRate() const;

--- a/PianoAligner.cpp
+++ b/PianoAligner.cpp
@@ -11,6 +11,7 @@
 #include <cmath> // delete later
 #include <filesystem>
 
+using namespace std;
 
 PianoAligner::PianoAligner(float inputSampleRate) :
     Plugin(inputSampleRate),
@@ -265,10 +266,10 @@ PianoAligner::getPrograms() const
 
     auto scores = Paths::getScores();
 
-    std::cerr << "PianoAligner::getPrograms: have " << scores.size() << " scores" << std::endl;
+    cerr << "PianoAligner::getPrograms: have " << scores.size() << " scores" << endl;
 
     for (auto score : scores) {
-        std::cerr << "PianoAligner::getPrograms: score " << score.first << std::endl;
+        cerr << "PianoAligner::getPrograms: score " << score.first << endl;
         list.push_back(score.first);
     }
 
@@ -288,7 +289,7 @@ void
 PianoAligner::selectProgram(string name)
 {
     m_scoreName = name;
-    std::cerr << "In selectProgram: name is -> " << name << '\n'; // ???
+    cerr << "In selectProgram: name is -> " << name << '\n'; // ???
 }
 
 PianoAligner::OutputList
@@ -320,8 +321,8 @@ PianoAligner::getOutputDescriptors() const
     d.hasFixedBinCount = true;
     /*
     if (m_blockSize == 0) {
-        //std::cerr << "m_blockSize is 0 in getOutputDescriptors()." << '\n';
-        std::cerr << "Sample Rate is " << m_inputSampleRate<<'\n';
+        //cerr << "m_blockSize is 0 in getOutputDescriptors()." << '\n';
+        cerr << "Sample Rate is " << m_inputSampleRate<<'\n';
         d.binCount = (512*6)/2 + 1;
     } else {
         d.binCount = m_blockSize/2 + 1;
@@ -405,10 +406,10 @@ PianoAligner::initialise(size_t channels, size_t stepSize, size_t blockSize)
 
     m_isFirstFrame = true;
 
-    std::cerr << "PianoAligner::initialise: score position start = "
+    cerr << "PianoAligner::initialise: score position start = "
               << m_scorePositionStart << ", end = " << m_scorePositionEnd
               << ", audio start = " << m_audioStart_sec << ", end = "
-              << m_audioEnd_sec << std::endl;
+              << m_audioEnd_sec << endl;
     
     // Real initialisation work goes here!
 
@@ -424,13 +425,13 @@ PianoAligner::initialise(size_t channels, size_t stepSize, size_t blockSize)
         if (getenv("PIANO_ALIGNER_USE_DEFAULT_SCORE") != nullptr) {
             auto programs = getPrograms();
             if (programs.empty()) {
-                std::cerr << "PianoAligner::initialise: No scores available" << std::endl;
+                cerr << "PianoAligner::initialise: No scores available" << endl;
                 return false;
             } else {
                 m_scoreName = programs[0];
             }
         } else {
-            std::cerr << "PianoAligner::initialise: No score selected" << std::endl;
+            cerr << "PianoAligner::initialise: No score selected" << endl;
             return false;
         }
     }
@@ -438,8 +439,8 @@ PianoAligner::initialise(size_t channels, size_t stepSize, size_t blockSize)
     if (m_aligner->loadAScore(m_scoreName, blockSize)) {
 	    return true;
     } else {
-        std::cerr << "PianoAligner::initialise: Failed to load score "
-		  << m_scoreName << std::endl;
+        cerr << "PianoAligner::initialise: Failed to load score "
+		  << m_scoreName << endl;
 	    return false;
     }
 }
@@ -460,7 +461,7 @@ PianoAligner::process(const float *const *inputBuffers, Vamp::RealTime timestamp
         m_firstFrameTime = timestamp; // 0.064000000R in simple-host; 0.000000000R in SV
         m_isFirstFrame = false;
         m_frameCount = 0;
-        std::cerr << "first frame time = "<<timestamp << '\n';
+        cerr << "first frame time = "<<timestamp << '\n';
     }
 
     int scale = 6; // hard-coded for now
@@ -568,25 +569,25 @@ PianoAligner::getRemainingFeatures()
     if (fabs(m_audioStart_sec - -1.) > .0000001) { // find the starting frame
         Vamp::RealTime t = Vamp::RealTime::fromSeconds(m_audioStart_sec);
         startFrame = Vamp::RealTime::realTime2Frame(t - m_firstFrameTime, m_inputSampleRate) / (128.*6.);
-        std::cerr<<"***Calculated starting frame is: "<<startFrame<<"; t="<<t<<std::endl;
+        cerr<<"***Calculated starting frame is: "<<startFrame<<"; t="<<t<<endl;
     }
 
     if (fabs(m_audioEnd_sec - -1.) > .0000001) { // find the ending frame
         Vamp::RealTime t = Vamp::RealTime::fromSeconds(m_audioEnd_sec);
         endFrame = Vamp::RealTime::realTime2Frame(t - m_firstFrameTime, m_inputSampleRate) / (128.*6.);
-        std::cerr<<"***Calculated ending frame is: "<<endFrame<<"; t="<<t<<"; m_frameCount="<<m_frameCount<<std::endl;
+        cerr<<"***Calculated ending frame is: "<<endFrame<<"; t="<<t<<"; m_frameCount="<<m_frameCount<<endl;
     }
 
     Score::MeasureInfo info = eventList[startEvent].measureInfo;
-    std::string label = to_string(info.measureNumber);
+    string label = to_string(info.measureNumber);
     label += "+" + to_string(info.measurePosition.numerator) + "/" + to_string(info.measurePosition.denominator);
-    std::cerr<<"***Start label is: "<<label<<std::endl;
+    cerr<<"***Start label is: "<<label<<endl;
     info = eventList[endEvent].measureInfo;
     label = to_string(info.measureNumber);
     label += "+" + to_string(info.measurePosition.numerator) + "/" + to_string(info.measurePosition.denominator);
-    std::cerr<<"***End label is: "<<label<<std::endl;
-    std::cerr<<"***Start frame is: "<<startFrame<<"; start second = "<<m_audioStart_sec<<"; m_firstFrameTime = "<<m_firstFrameTime<<std::endl;
-    std::cerr<<"***End frame is: "<<endFrame<<"; end second = "<<m_audioEnd_sec<<std::endl;
+    cerr<<"***End label is: "<<label<<endl;
+    cerr<<"***Start frame is: "<<startFrame<<"; start second = "<<m_audioStart_sec<<"; m_firstFrameTime = "<<m_firstFrameTime<<endl;
+    cerr<<"***End frame is: "<<endFrame<<"; end second = "<<m_audioEnd_sec<<endl;
     m_aligner->setAlignmentConstraints(startEvent, endEvent, startFrame, endFrame);
 
     // Window version:
@@ -597,13 +598,13 @@ PianoAligner::getRemainingFeatures()
         Feature feature;
         feature.hasTimestamp = true;
         feature.timestamp = m_firstFrameTime + Vamp::RealTime::frame2RealTime(frame*(128.*6.), m_inputSampleRate);
-        std::cerr <<"event="<<event<< ", real time = "<<feature.timestamp << '\n';
+        cerr <<"event="<<event<< ", real time = "<<feature.timestamp << '\n';
         Score::MeasureInfo info = eventList[event].measureInfo;
         // Calculate label:
         feature.label = to_string(info.measureNumber);
         feature.label += "+" + to_string(info.measurePosition.numerator) + "/" + to_string(info.measurePosition.denominator);
         
-        std::cerr<<"***TICKS: "<<feature.label<<" -> "<<eventList[event].tick<<std::endl;
+        cerr<<"***TICKS: "<<feature.label<<" -> "<<eventList[event].tick<<endl;
         feature.values.push_back(eventList[event].tick);
         featureSet[3].push_back(feature);
         frames.push_back(frame); // this feature not used?
@@ -620,7 +621,7 @@ PianoAligner::getRemainingFeatures()
             Feature feature;
             feature.hasTimestamp = true;
             feature.timestamp = m_firstFrameTime + Vamp::RealTime::frame2RealTime(frame, m_inputSampleRate/(128.*6.));
-            std::cout <<"real time = "<< feature.timestamp << '\n';
+            cout <<"real time = "<< feature.timestamp << '\n';
             feature.label = to_string(result);
             featureSet[3].push_back(feature);
             currentEvent = result;
@@ -656,7 +657,7 @@ PianoAligner::getRemainingFeatures()
         }
     }
     double range = max-min; // Shouldn't be zero, but need to check
-    std::cout << "max = "<<max<<", min="<<min << '\n';
+    cout << "max = "<<max<<", min="<<min << '\n';
     for (const auto& spectrum: m_aligner->getDataFeatures()) {
         Feature feature;
         feature.hasTimestamp = false;
@@ -673,28 +674,28 @@ PianoAligner::getRemainingFeatures()
 
     //Testing note templates:
 /*
-    std::cout<<"m_blockSize = "<<(m_blockSize / 2)<<"\n";
+    cout<<"m_blockSize = "<<(m_blockSize / 2)<<"\n";
     NoteTemplates t = CreateNoteTemplates::getNoteTemplates(
         m_inputSampleRate, m_blockSize);
     for (auto &pair : t) {
         int midi = pair.first;
         Template &spect = pair.second;
-        std::cout<<"### MIDI: "<<midi<<" ###"<<"\n";
+        cout<<"### MIDI: "<<midi<<" ###"<<"\n";
         for (auto value: spect) {
-            std::cout<<value<<",";
+            cout<<value<<",";
         }
-        std::cout<<"\n";
+        cout<<"\n";
     }
 */
 /*
     //Testing event templates:
     int index = 1;
     for (const auto &event: m_aligner->getScore().getMusicalEvents()) {
-        std::cout<<"### Event: "<<index<<" ###"<<"\n";
+        cout<<"### Event: "<<index<<" ###"<<"\n";
         for (const auto &value: event.eventTemplate) {
-            std::cout<<value<<",";
+            cout<<value<<",";
         }
-        std::cout<<"\n";
+        cout<<"\n";
         index++;
     }
 */

--- a/PianoAligner.cpp
+++ b/PianoAligner.cpp
@@ -579,12 +579,10 @@ PianoAligner::getRemainingFeatures()
     }
 
     Score::MeasureInfo info = eventList[startEvent].measureInfo;
-    string label = to_string(info.measureNumber);
-    label += "+" + to_string(info.measurePosition.numerator) + "/" + to_string(info.measurePosition.denominator);
+    string label = info.toLabel();
     cerr<<"***Start label is: "<<label<<endl;
     info = eventList[endEvent].measureInfo;
-    label = to_string(info.measureNumber);
-    label += "+" + to_string(info.measurePosition.numerator) + "/" + to_string(info.measurePosition.denominator);
+    label = info.toLabel();
     cerr<<"***End label is: "<<label<<endl;
     cerr<<"***Start frame is: "<<startFrame<<"; start second = "<<m_audioStart_sec<<"; m_firstFrameTime = "<<m_firstFrameTime<<endl;
     cerr<<"***End frame is: "<<endFrame<<"; end second = "<<m_audioEnd_sec<<endl;
@@ -601,9 +599,7 @@ PianoAligner::getRemainingFeatures()
         cerr <<"event="<<event<< ", real time = "<<feature.timestamp << '\n';
         Score::MeasureInfo info = eventList[event].measureInfo;
         // Calculate label:
-        feature.label = to_string(info.measureNumber);
-        feature.label += "+" + to_string(info.measurePosition.numerator) + "/" + to_string(info.measurePosition.denominator);
-        
+        feature.label = info.toLabel();
         cerr<<"***TICKS: "<<feature.label<<" -> "<<eventList[event].tick<<endl;
         feature.values.push_back(eventList[event].tick);
         featureSet[3].push_back(feature);

--- a/PianoAligner.h
+++ b/PianoAligner.h
@@ -11,8 +11,6 @@
 
 #include "AudioToScoreAligner.h"
 
-using std::string;
-
 
 class PianoAligner : public Vamp::Plugin
 {
@@ -20,12 +18,12 @@ public:
     PianoAligner(float inputSampleRate);
     virtual ~PianoAligner();
 
-    string getIdentifier() const;
-    string getName() const;
-    string getDescription() const;
-    string getMaker() const;
+    std::string getIdentifier() const;
+    std::string getName() const;
+    std::string getDescription() const;
+    std::string getMaker() const;
     int getPluginVersion() const;
-    string getCopyright() const;
+    std::string getCopyright() const;
 
     InputDomain getInputDomain() const;
     size_t getPreferredBlockSize() const;
@@ -34,12 +32,12 @@ public:
     size_t getMaxChannelCount() const;
 
     ParameterList getParameterDescriptors() const;
-    float getParameter(string identifier) const;
-    void setParameter(string identifier, float value);
+    float getParameter(std::string identifier) const;
+    void setParameter(std::string identifier, float value);
 
     ProgramList getPrograms() const;
-    string getCurrentProgram() const;
-    void selectProgram(string name);
+    std::string getCurrentProgram() const;
+    void selectProgram(std::string name);
 
     OutputList getOutputDescriptors() const;
 
@@ -70,7 +68,7 @@ protected:
     bool m_isFirstFrame;
     Vamp::RealTime m_firstFrameTime;
     int m_frameCount;
-    string m_scoreName;
+    std::string m_scoreName;
 };
 
 

--- a/Score.cpp
+++ b/Score.cpp
@@ -9,10 +9,6 @@
 #include <string>
 
 
-
-
-
-
 using namespace std;
 
 Score::Score()
@@ -273,15 +269,15 @@ void Score::calculateTicks()
                 lastChangeTick = currentTick;
             }
         }
-        //std::string label = to_string(info.measureNumber);
+        //string label = to_string(info.measureNumber);
         //label += "+" + to_string(info.measurePosition.numerator) + "/" + to_string(info.measurePosition.denominator);
-        //std::cerr<<"***Score ticks: "<<label<<" -> "<<currentTick<<std::endl;
+        //cerr<<"***Score ticks: "<<label<<" -> "<<currentTick<<endl;
         // feature.values.push_back(info.measureFraction.numerator * 2000 / info.measureFraction.denominator);
         m_musicalEvents[event].tick = currentTick;
     }
 }
 
-std::ostream& operator<<(std::ostream &strm, Fraction &f) {
+ostream& operator<<(ostream &strm, Fraction &f) {
    return strm << to_string(f.numerator) << "/" << to_string(f.denominator);
 }
 
@@ -294,7 +290,7 @@ void Score::setEventTemplates(NoteTemplates& t)
 {
     int bins = t[60].size();
     if (bins <= 0) {
-        std::cerr << "setEventTemplates: Something is wrong with the note templates." << '\n';
+        cerr << "setEventTemplates: Something is wrong with the note templates." << '\n';
         return;
     }
     double smallValue = 1 / (double)bins;
@@ -338,7 +334,7 @@ int main()
         // Testing code:
         for (Score::MusicalEvent event: events) {
             cout<<"***MEASURE: "<<event.measureInfo.measureFraction<<endl;
-            std::cout << "duration: " << event.duration << '\n';
+            cout << "duration: " << event.duration << '\n';
             for (Score::Note note: event.notes) {
                 cout<<note.isNewNote<<"\t"<<note.midiNumber<<endl;
             }

--- a/Score.cpp
+++ b/Score.cpp
@@ -277,7 +277,7 @@ void Score::calculateTicks()
     }
 }
 
-ostream& operator<<(ostream &strm, Fraction &f) {
+ostream& operator<<(ostream &strm, const Fraction &f) {
    return strm << to_string(f.numerator) << "/" << to_string(f.denominator);
 }
 

--- a/Score.cpp
+++ b/Score.cpp
@@ -70,13 +70,17 @@ bool Score::initialize(string scoreFilePath)
         getline(iss, s, '\t');
         int velocity = stoi(s);
 
+        // noteId
+        string noteId;
+        getline(iss, noteId, '\t');
+
 
         if (m != currentMeasure) { // new event
 
             if (currentMeasure != "") { // skip the beginning measure
                 // Add continuing notes, if any, from the last event.
                 for (Note note: continuingNotes)
-                    currentEvent.notes.push_back(Note(false, note.midiNumber));
+                    currentEvent.notes.push_back(Note(false, note.midiNumber, noteId));
                 currentEvent.duration = measureFraction - currentEvent.measureInfo.measureFraction;
                 m_musicalEvents.push_back(currentEvent);
                 continuingNotes = currentEvent.notes;
@@ -97,7 +101,7 @@ bool Score::initialize(string scoreFilePath)
                 }
             }
         } else // If it's an in note, add it to the currentEvent.
-            currentEvent.notes.push_back(Note(true, midi));
+            currentEvent.notes.push_back(Note(true, midi, noteId));
     }
 
     return true;
@@ -163,10 +167,12 @@ bool Score::readTempo(string tempoFilePath)
                 event.tempo = last.newTempo * last.noteLength;
     }
     // testing:
+    /*
     for (auto &event: m_musicalEvents) {
         cerr<<"***TEMPO: "<<event.measureInfo.measureNumber<<"+"
                  <<event.measureInfo.measurePosition<<" -> "<<event.tempo<<endl;
     }
+    */
 
     return true;
 }
@@ -229,11 +235,13 @@ bool Score::readMeter(string meterFilePath)
             event.meterDenom = last.denom;
         }
     // testing:
+    /*
     for (auto &event: m_musicalEvents) {
         cerr<<"***METER: "<<event.measureInfo.measureNumber<<"+"
                  <<event.measureInfo.measurePosition<<" -> "<<
                  event.meterNumer<<"/"<<event.meterDenom<<endl;
     }
+    */
 
     return true;
 }

--- a/Score.h
+++ b/Score.h
@@ -123,8 +123,9 @@ public:
     {
         bool isNewNote; // is an emerging note as opposed to a continuing note
         int midiNumber;
+        string noteId; // from MEI
 
-        Note(bool nn, int mn) : isNewNote{nn}, midiNumber{mn} { }
+        Note(bool nn, int mn, string ni) : isNewNote{nn}, midiNumber{mn}, noteId{ni} { }
     };
 
     struct MusicalEvent

--- a/Score.h
+++ b/Score.h
@@ -14,13 +14,6 @@
 #include "Templates.h"
 
 
-using std::istringstream;
-using std::vector;
-using std::stoi;
-using std::string;
-using std::to_string;
-
-
 struct Fraction // Simplest form using GCD.
 {
     int numerator;
@@ -41,9 +34,9 @@ struct Fraction // Simplest form using GCD.
         }
     }
 
-    static Fraction fromString(const string &s) {
-        string n, d;
-        istringstream iss(s);
+    static Fraction fromString(const std::string &s) {
+        std::string n, d;
+        std::istringstream iss(s);
         getline(iss, n, '/');
         getline(iss, d, '/');
         return Fraction(stoi(n), stoi(d));
@@ -123,15 +116,15 @@ public:
     {
         bool isNewNote; // is an emerging note as opposed to a continuing note
         int midiNumber;
-        string noteId; // from MEI
+        std::string noteId; // from MEI
 
-        Note(bool nn, int mn, string ni) : isNewNote{nn}, midiNumber{mn}, noteId{ni} { }
+        Note(bool nn, int mn, std::string ni) : isNewNote{nn}, midiNumber{mn}, noteId{ni} { }
     };
 
     struct MusicalEvent
     {
         MeasureInfo measureInfo;
-        vector<Note> notes;
+        std::vector<Note> notes;
         Template eventTemplate;
         Fraction duration;
         float tempo; // e.g., Quarter note = 120.0
@@ -162,13 +155,13 @@ public:
         MeterChange(int mn, int n, int d): measureNumber{mn}, numer{n}, denom{d} { }
     };
 
-    typedef vector<MusicalEvent> MusicalEventList;
-    typedef vector<TempoChange> TempoChangeList;
-    typedef vector<MeterChange> MeterChangeList;
+    typedef std::vector<MusicalEvent> MusicalEventList;
+    typedef std::vector<TempoChange> TempoChangeList;
+    typedef std::vector<MeterChange> MeterChangeList;
 
-    bool initialize(string scoreFilePath);
-    bool readTempo(string tempoFilePath);
-    bool readMeter(string meterFilePath);
+    bool initialize(std::string scoreFilePath);
+    bool readTempo(std::string tempoFilePath);
+    bool readMeter(std::string meterFilePath);
     void calculateTicks();
 
     const MusicalEventList& getMusicalEvents() const;

--- a/Score.h
+++ b/Score.h
@@ -77,7 +77,7 @@ struct Fraction // Simplest form using GCD.
     }
 };
 
-std::ostream& operator<<(std::ostream &strm, Fraction &f);
+std::ostream& operator<<(std::ostream &strm, const Fraction &f);
 
 class Score
 {

--- a/Score.h
+++ b/Score.h
@@ -110,6 +110,12 @@ public:
         bool operator>=(const MeasureInfo& other) const { // ignore measureFraction
             return (*this == other) || (other < *this);
         }
+
+        std::string toLabel() const {
+            return std::to_string(measureNumber) + "+"
+                + std::to_string(measurePosition.numerator) + "/"
+                + std::to_string(measurePosition.denominator);
+        }
     };
 
     struct Note

--- a/SimpleHMM.h
+++ b/SimpleHMM.h
@@ -11,8 +11,6 @@
 #include <map>
 #include <sstream> // for printing probs with high precision
 
-using std::vector;
-
 
 class SimpleHMM
 {
@@ -51,8 +49,8 @@ public:
             return !( (*this < other) || (*this == other) );
         }
 
-        static string toString(const State& s) {
-            string ss = to_string(s.eventIndex) + "\t" + to_string(s.microIndex);
+        static std::string toString(const State& s) {
+            std::string ss = std::to_string(s.eventIndex) + "\t" + std::to_string(s.microIndex);
             /*
             for (auto& p : s.nextStates) {
                 ss += "\t next: " + to_string(p.first->eventIndex) +
@@ -99,7 +97,7 @@ public:
             return !( (*this < other) || (*this == other) );
         }
 
-        static string toString(const Hypothesis& h) {
+        static std::string toString(const Hypothesis& h) {
             std::ostringstream out;
             out.precision(38);
             out << std::fixed << h.prob;
@@ -110,12 +108,12 @@ public:
     };
 
     AudioToScoreAligner::AlignmentResults getAlignmentResults();
-    const map<State, map<State, double>>& getNextStates() const;
+    const std::map<State, std::map<State, double>>& getNextStates() const;
 
 private:
     AudioToScoreAligner m_aligner;
-    map<State, map<State, double>> m_nextStates; // value is <next state, trans prob>
-    map<State, map<State, double>> m_prevStates; // value is <prev state, trans prob>
+    std::map<State, std::map<State, double>> m_nextStates; // value is <next state, trans prob>
+    std::map<State, std::map<State, double>> m_prevStates; // value is <prev state, trans prob>
 };
 
 #endif

--- a/Templates.cpp
+++ b/Templates.cpp
@@ -9,7 +9,7 @@
 #include <map>
 #include <vector>
 
-
+using namespace std;
 
 static const int LOW_MIDI = 21;
 static const int HIGH_MIDI = 108;
@@ -58,7 +58,7 @@ static void initializeNoteTemplates(float sr, int blockSize, NoteTemplates& t) {
                 float x = (k-bin)/sigma;
                 t[midi][k] += exp(-k*0.01)*peakFunction(x) / sigma; // 0.01//0.1
                 //if (peakFunction(x) == 0) {
-                    //std::cerr << "!!!!peakFunction returns 0: midi=" << midi <<"bin="<<bin<<"k="<<k<< '\n';
+                    //cerr << "!!!!peakFunction returns 0: midi=" << midi <<"bin="<<bin<<"k="<<k<< '\n';
                 //}
             }
             h++;
@@ -70,7 +70,7 @@ static void initializeNoteTemplates(float sr, int blockSize, NoteTemplates& t) {
             total += value;
         }
         if (total == 0.) {
-            std::cerr << "In initializeNoteTemplates: total is 0 for midi "<< midi << '\n'; // midi 108 exceeds 4k Hz.
+            cerr << "In initializeNoteTemplates: total is 0 for midi "<< midi << '\n'; // midi 108 exceeds 4k Hz.
         } else {
             for (auto &value: t[midi]) {
                 value /= total;

--- a/Templates.h
+++ b/Templates.h
@@ -8,12 +8,8 @@
 #include <map>
 #include <vector>
 
-using std::map;
-using std::vector;
-
-typedef vector<float> Template; // for an individual note, or for a musical event
-typedef map<int, Template> NoteTemplates; // key is midi
-
+typedef std::vector<float> Template; // for an individual note, or for a musical event
+typedef std::map<int, Template> NoteTemplates; // key is midi
 
 struct CreateNoteTemplates {
     static const NoteTemplates& getNoteTemplates(float sampleRate, int blockSize);
@@ -25,9 +21,9 @@ public:
     static const int LOW_MIDI = 21;
     static const int HIGH_MIDI = 108;
     static void initializeNoteTemplates(int sampleRate, int blockSize);
-    static map<int, Template>& getNoteTemplates();
+    static std::map<int, Template>& getNoteTemplates();
 private:
-    static map<int, Template> m_noteTemplates; // key is midi
+    static std::map<int, Template> m_noteTemplates; // key is midi
     static bool initialized = false;
 };
 */


### PR DESCRIPTION
The main change here is to add a `toLabel` method to `MeasureInfo`, since I had found myself duplicating the logic in `PianoAligner.cpp` a couple of times.

I also did a little bit of tidying that I hope won't be too annoying - e.g. removing using-declarations from headers (because they introduce the namespaced names into all the files that include them). See what you think.

At the moment my `verovio` branch depends on this change, so take a look and see if you think it's ok to merge it! Let me know if not.
